### PR TITLE
Replace nullptr with null in iOS

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3781,7 +3781,7 @@ _SOKOL_PRIVATE bool _sapp_app_delegate_didFinishLaunchingWithOptions(NSDictionar
         _sapp.ios.view.autoResizeDrawable = false;
         _sapp.ios.view.userInteractionEnabled = YES;
         _sapp.ios.view.multipleTouchEnabled = YES;
-		if(viewController != nullptr) {
+		if(viewController != nil) {
 			_sapp.ios.view_ctrl = viewController;
 		} else {
 			_sapp.ios.view_ctrl = [[UIViewController alloc] init];
@@ -3859,7 +3859,7 @@ _SOKOL_PRIVATE void _sapp_app_delegate_applicationWillTerminate(UIApplication* a
 
 @implementation _sapp_app_delegate
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    return _sapp_app_delegate_didFinishLaunchingWithOptions(launchOptions, nullptr);
+    return _sapp_app_delegate_didFinishLaunchingWithOptions(launchOptions, nil);
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {


### PR DESCRIPTION
Since nullptr doesn't exist in C, use null instead. This allows including our fork of sokol in `.m` files for iOS.